### PR TITLE
Use a random source for key generation

### DIFF
--- a/upload/library/XenforoApiKeys/ControllerPublic/Index.php
+++ b/upload/library/XenforoApiKeys/ControllerPublic/Index.php
@@ -29,7 +29,7 @@ class XenforoApiKeys_ControllerPublic_Index extends XenForo_ControllerPublic_Abs
 
         $writer = XenForo_DataWriter::create("XenforoApiKeys_DataWriter_ApiKey");
         $writer->set('user_id', $user['user_id']);
-        $writer->set('key', $this->_getApiKeyModel()->generateKey($user));
+        $writer->set('key', $this->_getApiKeyModel()->generateKey());
         $writer->save();
 
         if ($this->_noRedirect()) {
@@ -50,7 +50,7 @@ class XenforoApiKeys_ControllerPublic_Index extends XenForo_ControllerPublic_Abs
 
         $writer = XenForo_DataWriter::create("XenforoApiKeys_DataWriter_ApiKey");
         $writer->setExistingData($user['user_id'], true);
-        $writer->set('key', $this->_getApiKeyModel()->generateKey($user));
+        $writer->set('key', $this->_getApiKeyModel()->generateKey());
         $writer->save();
 
         if ($this->_noRedirect()) {

--- a/upload/library/XenforoApiKeys/Model/ApiKey.php
+++ b/upload/library/XenforoApiKeys/Model/ApiKey.php
@@ -6,12 +6,7 @@ class XenforoApiKeys_Model_ApiKey extends XenForo_Model {
     }
 
     // maybe shouldn't be in the model. but whatever, lol.
-    public function generateKey($user) {
-        // turns the string "{id}-{email}-{register date}-{unix time}" into a hash
-        // this will be the api key
-        return hash(
-            "sha256", 
-            $user['user_id'] . "-" . $user['email'] . "-" . $user['register_date'] . "-" . microtime()
-        );
+    public function generateKey() {
+        return hash("sha256", bin2hex(random_bytes(32)));
     }
 }


### PR DESCRIPTION
Closes #2.

Switch to using a random source for key generation. [random_bytes](https://www.php.net/manual/en/function.random-bytes.php) is noted to be cryptographically secure.